### PR TITLE
Fix to autoplay not working

### DIFF
--- a/flexbox-form/index.html
+++ b/flexbox-form/index.html
@@ -36,7 +36,7 @@
 
   </div>
   
-  <video  class="dog" src="Coverr-Lulu/Coverr-Lulu.webm" autoplay loop></video>
+  <video  class="dog" src="Coverr-Lulu/Coverr-Lulu.webm" autoplay muted loop></video>
 
 </body>
 </html>


### PR DESCRIPTION
In lesson 19 the video doesn't `autoplay` (in Chrome) this is because it is required to add the property `muted` to the `video` tag for the `autoplay` to work.

This fixes #26 