### PR TITLE
Deleted flex 1 from .icon-bar at general layout

### DIFF
--- a/flexbox-app-layout/style-START.css
+++ b/flexbox-app-layout/style-START.css
@@ -56,7 +56,6 @@ a.button {
 
 
 .icon-bar a {
-  flex:1;
   text-align: center;
   padding:1.5rem;
   border-left:1px solid rgba(0,0,0,0.1);

--- a/flexbox-app-layout/style.css
+++ b/flexbox-app-layout/style.css
@@ -56,7 +56,6 @@ a.button {
 
 
 .icon-bar a {
-  flex:1;
   text-align: center;
   padding:1.5rem;
   border-left:1px solid rgba(0,0,0,0.1);


### PR DESCRIPTION
Removed flex 1 property from style-START.css and style.css because it appears in .icon-bar at the general css layout section .and not in the flexbox related css