### PR TITLE
Update mobile-reordering initial style.css to match video

### DIFF
--- a/mobile-reordering/style.css
+++ b/mobile-reordering/style.css
@@ -64,9 +64,32 @@ section, footer {
   list-style: none;
   margin: 0;
   padding: 0;
+  display:flex;
 }
 
+/* Flex Item */
+.flex-nav li {
+  flex:3;
+}
+
+.flex-nav .social {
+  flex:1;
+}
+
+
 @media all and (max-width:1000px) {
+  
+  .flex-nav ul {
+    flex-wrap:wrap;
+  }
+
+  .flex-nav li {
+    flex:1 1 50%;
+  }
+
+  .flex-nav .social {
+    flex:1 1 25%;
+  }
 
 }
 


### PR DESCRIPTION
In the Mobile Reordering video, the style.css starter file includes all the Flexbox Nav rules (from the "Pure Flexbox navigation code along" video), but the style.css file in the repo doesn't.

This PR adds the Flexbox Nav rules to the Mobile Reordering style.css starter file so it matches what's in the video's style.css starter file.

P.S. Thanks for making these terrific tutorials! 🤩